### PR TITLE
update v1.1 license templates from 2018 to 2020

### DIFF
--- a/cisco-sample-code-license/v1.1/CISCO-SAMPLE-CODE-LICENSE-V1.1.html
+++ b/cisco-sample-code-license/v1.1/CISCO-SAMPLE-CODE-LICENSE-V1.1.html
@@ -6,7 +6,7 @@
     <body>
         <p align=center style="margin: 0">CISCO SAMPLE CODE LICENSE</p>
         <p align=center style="margin: 0">Version 1.1</p>
-        <p align=center style="margin: 0">Copyright (c) 2018 Cisco and/or its affiliates</p>
+        <p align=center style="margin: 0">Copyright (c) 2020 Cisco and/or its affiliates</p>
 
         <p>These terms govern this Cisco Systems, Inc. ("Cisco"), example or demo source code and its associated documentation (together, the "Sample Code"). By downloading, copying, modifying, compiling, or redistributing the Sample Code, you accept and agree to be bound by the following terms and conditions (the "License"). If you are accepting the License on behalf of an entity, you represent that you have the authority to do so (either you or the entity, "you"). Sample Code is not supported by Cisco TAC and is not tested for quality or performance. This is your only license to the Sample Code and all rights not expressly granted are reserved.</p>
         

--- a/cisco-sample-code-license/v1.1/CISCO-SAMPLE-CODE-LICENSE-V1.1.txt
+++ b/cisco-sample-code-license/v1.1/CISCO-SAMPLE-CODE-LICENSE-V1.1.txt
@@ -1,6 +1,6 @@
                            CISCO SAMPLE CODE LICENSE
                                   Version 1.1
-                Copyright (c) 2018 Cisco and/or its affiliates
+                Copyright (c) 2020 Cisco and/or its affiliates
 
    These terms govern this Cisco Systems, Inc. ("Cisco"), example or demo
    source code and its associated documentation (together, the "Sample


### PR DESCRIPTION
This PR addresses issue #3.
Robert already submitted a PR to update the copyright year of the sample LICENSE in the main directory. This PR updates the copyright year in the v1.1 LICENSE templates.